### PR TITLE
Enable timeouts when reading from /dev/alog/*

### DIFF
--- a/logger_reader_test.go
+++ b/logger_reader_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,9 +17,12 @@ func readFromLogWorks(log LogId, t *testing.T) {
 	lr, err := NewLoggerReader(log)
 	assert.Nil(t, err)
 
+	lr.SetDeadline(time.Now().Add(500 * time.Millisecond))
+
 	atLeastOne := false
 
 	for entry, err := lr.ReadNext(); err == nil; entry, err = lr.ReadNext() {
+		lr.SetDeadline(time.Now().Add(500 * time.Millisecond))
 		atLeastOne = true
 		t.Logf("%+v\n", entry)
 	}

--- a/reader.go
+++ b/reader.go
@@ -2,13 +2,18 @@ package alog
 
 import (
 	"errors"
+	"time"
 )
 
 // ErrReadTimeout is returned if a call to ReadNext times out.
 var ErrReadTimeout = errors.New("Reading the next entry from the log timed out")
 
 type Reader interface {
-	// ReadNext reads the next entry from a Reader.
+	// SetDeadline adjusts the deadline such that all subsequent calls to
+	// ReadNext will fail if they exceed t.
+	SetDeadline(t time.Time) error
+
+	// ReadNext reads the next entry from a Reader
 	//
 	// Returns an error if reading the next entry fails.
 	// Returns ErrReadTimeout in case of timeouts.


### PR DESCRIPTION
Rely on https://github.com/npat-efault/poller to enable timeouts on ordinary
file descriptors and add SetDeadline to the Reader interface to mimic functionality
known from the net package.
