### PR TITLE
Add interface Writer and an impl LoggerReader

### DIFF
--- a/logger_writer.go
+++ b/logger_writer.go
@@ -1,0 +1,47 @@
+package alog
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/tedb/vectorio"
+)
+
+// A LoggerWriter implements Writer, sending log entries to Android's kernel logger.
+type LoggerWriter struct {
+	f *os.File // Open File representing our connection to Android's kernel logger.
+}
+
+// NewLoggerWriter opens a connection to Android's kernel logger for id,
+// returning a LoggerWriter if the operation finishes sucessfully.
+//
+// Returns an error if connection to the Android kernel logger with id fails.
+func NewLoggerWriter(id LogId) (*LoggerWriter, error) {
+	fn := filepath.Join("/dev", "alog", id.String())
+
+	f, err := os.OpenFile(fn, os.O_RDWR, 0666)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LoggerWriter{f: f}, nil
+}
+
+// Close shuts down the connection to Android's kernel logger.
+func (self *LoggerWriter) Close() error {
+	return self.f.Close()
+}
+
+// Write sends a log with prio, tag and message to Android's kernel logger.
+//
+// Returns an error if writing to the kernel logger fails.
+func (self *LoggerWriter) Write(prio Priority, tag Tag, message string) error {
+	iov := [][]byte{
+		[]byte{byte(prio)},
+		[]byte(tag),
+		[]byte(message),
+	}
+
+	_, err := vectorio.Writev(self.f, iov)
+	return err
+}

--- a/logger_writer_test.go
+++ b/logger_writer_test.go
@@ -1,0 +1,42 @@
+package alog
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var testTag = Tag("Test")
+
+func testLoggerWriterWorks(logId LogId, t *testing.T) {
+	skipIfNoAndroidLoggingFacilities(logId, t)
+
+	writer, err := NewLoggerWriter(logId)
+	require.NoError(t, err)
+
+	defer writer.Close()
+
+	writer.Write(PriorityDebug, testTag, "42")
+
+	reader, err := NewLoggerReader(logId, LoggerAbiV1)
+	require.NoError(t, err)
+
+	defer reader.Close()
+
+	reader.SetDeadline(time.Now().Add(500 * time.Millisecond))
+	entry, err := reader.ReadNext()
+
+	require.NoError(t, err)
+
+	assert.Equal(t, testTag, entry.Tag)
+	assert.Equal(t, PriorityDebug, entry.Priority)
+	assert.Equal(t, "42", entry.Message)
+}
+
+func TestLoggerWriteWorks(t *testing.T) {
+	testLoggerWriterWorks(LogIdMain, t)
+	testLoggerWriterWorks(LogIdRadio, t)
+	testLoggerWriterWorks(LogIdEvents, t)
+	testLoggerWriterWorks(LogIdSystem, t)
+}

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,16 @@
+package alog
+
+import (
+	"io"
+)
+
+// A Writer allows for logging to Android's logging facilities.
+type Writer interface {
+	// A Writer needs to be closed explicitly
+	io.Closer
+
+	// Write logs an message with priority prio and a tag.
+	//
+	// Returns an error if writing to the underlying Android logging facilities fails.
+	Write(prio Priority, tag Tag, message string) error
+}


### PR DESCRIPTION
Writer abstracts logging entries to Android's logging facilities.
LoggerReader implements the interface, talking to Android's pre-Lollipop
kernel logging facilities.
