### PR TITLE
Add a function SetDeadline to Writer.

### DIFF
--- a/logger_writer.go
+++ b/logger_writer.go
@@ -3,6 +3,7 @@ package alog
 import (
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/tedb/vectorio"
 )
@@ -30,6 +31,13 @@ func NewLoggerWriter(id LogId) (*LoggerWriter, error) {
 // Close shuts down the connection to Android's kernel logger.
 func (self *LoggerWriter) Close() error {
 	return self.f.Close()
+}
+
+// SetDeadline is noop for LoggerWriter. The Android kernel logging
+// facilities always report the underlying file as writable. For that,
+// polling would be pointless and we can just hand out our write request.
+func (self *LoggerWriter) SetDeadline(t time.Time) error {
+	return nil
 }
 
 // Write sends a log with prio, tag and message to Android's kernel logger.

--- a/reader.go
+++ b/reader.go
@@ -13,6 +13,7 @@ var ErrReadTimeout = errors.New("Reading the next entry from the log timed out")
 type Reader interface {
 	// A Reader has to be closed explicitly.
 	io.Closer
+
 	// SetDeadline adjusts the deadline such that all subsequent calls to
 	// ReadNext will fail if they exceed t.
 	SetDeadline(t time.Time) error

--- a/writer.go
+++ b/writer.go
@@ -2,12 +2,17 @@ package alog
 
 import (
 	"io"
+	"time"
 )
 
 // A Writer allows for logging to Android's logging facilities.
 type Writer interface {
 	// A Writer needs to be closed explicitly
 	io.Closer
+
+	// SetDeadline adjusts the deadline such that all subsequent calls to
+	// ReadNext will fail if they exceed t.
+	SetDeadline(t time.Time) error
 
 	// Write logs an message with priority prio and a tag.
 	//


### PR DESCRIPTION
Writer now is consistent with the Reader interface with adding
SetDeadline to Writer.
LoggerWriter provides an empty impl of SetDeadline as the Android
kernel logging facilities always report the underlying file as readable.
